### PR TITLE
Remove deprecated Image.ANTIALIAS constant

### DIFF
--- a/Iconolatry.py
+++ b/Iconolatry.py
@@ -1022,7 +1022,7 @@ class Encode(object):
                 image = self.extract(path_image)
 
                 ## Manage resize.
-                image = self.ico_resize(image, how = self.type_resize, method = Image.ANTIALIAS)
+                image = self.ico_resize(image, how = self.type_resize, method = Image.LANCZOS)
 
                 ## Manage ICC profile.
                 if 'icc_profile' in image.info:
@@ -1220,7 +1220,7 @@ class Encode(object):
                                 temp.append(self.parameters['palette'][i : i + step][::-1] + b'\x00')
                         self.parameters['palette'] = b"".join(temp)
 
-        def ico_resize(self, image, how = 'up256_prop', method = Image.ANTIALIAS):
+        def ico_resize(self, image, how = 'up256_prop', method = Image.LANCZOS):
                 """ Resizes to `.ico` / `.cur` dimensions. """
                 old_w, old_h = image.size
                 sizes = [16, 24, 32, 48, 64, 128, 256]

--- a/Metamorphosis.py
+++ b/Metamorphosis.py
@@ -264,7 +264,7 @@ class Editor(object):
                 self.parameters = parameters
                 self.options = options
 
-        def resize_meth(self, image, method = Image.ANTIALIAS):
+        def resize_meth(self, image, method = Image.LANCZOS):
                 """ Resizes PIL image to a maximum size specified maintaining the aspect ratio.
                     Allows usage of different resizing methods and does not modify the image in place,
                     then creates an exact square image.
@@ -297,7 +297,7 @@ class Editor(object):
                 scale_x = w_fin / w_ini
                 scale_y = h_fin / h_ini
 
-                image_list = [self.resize_meth(image_list[i], method = Image.ANTIALIAS) for i in range(self.parameters['count'])]
+                image_list = [self.resize_meth(image_list[i], method = Image.LANCZOS) for i in range(self.parameters['count'])]
 
                 ## Scale hotspots.
                 self.parameters['hotx'] = int(0.5 * ceil(2.0 * (self.parameters['hotx'] * scale_x)))


### PR DESCRIPTION
This commit removes the deprecated Image.ANTIALIAS constant. Use Image.LANCZOS instead.

This commit fixes the following error:

AttributeError: module 'PIL.Image' has no attribute 'ANTIALIAS'

The error occurs because the Image.ANTIALIAS constant was removed in Pillow 10.0.0. 
To fix the error, simply replace any occurrences of Image.ANTIALIAS with Image.LANCZOS.

For more information, see https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#constants.